### PR TITLE
Handle ^C gracefully & predictably (i.e. do nothing...)

### DIFF
--- a/simple_cli.py
+++ b/simple_cli.py
@@ -134,6 +134,7 @@ Changelog
 import threading
 import socket
 import socketserver
+import signal
 import sys
 import platform
 import code
@@ -294,8 +295,12 @@ def reconnect():
         sys.exit("A connection error occurred: %s" % e)
 
 
+def signal_handler(signal, frame):
+        print('Please use "exit" to quit.')
 
 if __name__ == '__main__':
+
+    signal.signal(signal.SIGINT, signal_handler)
 
     # Fair warning
     if os_version == 'Darwin':


### PR DESCRIPTION
This is just for now.  I am not sure what you want ^C to do, exactly.  Does it stop the running state machines and goes back to the C> prompt? Does it exit the simple-cli entirely?

As an aside, it would be good if there was a mechanism to abort all internal running behaviours (i.e. emergency stop), in a safe and predictable manner, ideally without side-effects... Coroutines would exit, threads would be stopped, etc...  and we would simply get back the 'C>' prompt, ready to go.That could be quite a bit more complicated to do than just asking for it here. :)

For now, simply catching the signal will at least make its behaviour predictable and safe.

