### PR TITLE
Fix crash when charger object is not initialized

### DIFF
--- a/world_viewer.py
+++ b/world_viewer.py
@@ -317,7 +317,7 @@ def make_floor():
 
 def make_charger():
     charger = robot.world.charger
-    if (not charger.pose) or not charger.pose.is_valid: return None
+    if (not charger) or (not charger.pose) or not charger.pose.is_valid: return None
     comparable = charger.pose.is_comparable(robot.pose)
     highlight = charger.is_visible or (robot.is_on_charger and comparable)
     c = glGenLists(1)


### PR DESCRIPTION
I had an issue in which you show the charger to Cozmo, restart the application and the charger is None so it crashes.

Just did an extra step to check that charger is not 'None'.