### PR TITLE
Fix simple_cli on machines where Python is installed in a nonstandard location

### DIFF
--- a/simple_cli
+++ b/simple_cli
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 """
 
 Simple Cozmo CLI

--- a/simple_cli.old
+++ b/simple_cli.old
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -i
+#!/usr/bin/env python3 -i
 """
 
 Simple Cozmo CLI


### PR DESCRIPTION
On some machines (especially Macs with homebrew) Python3 is not always in `/usr/bin/python3`, using `/usr/bin/env python3` is more portable and still works across Linux and macOS machines.

It seems like some of the other scripts in the repo (`genfsm`) already use the `/usr/bin/env` solution, but `simple_cli` had not been updated, this PR fixes that.